### PR TITLE
Update ovapi.py

### DIFF
--- a/ovapi.py
+++ b/ovapi.py
@@ -16,12 +16,13 @@ from homeassistant.util import Throttle
 
 import homeassistant.helpers.config_validation as cv
 
-__version__ = '1.2.1'
+__version__ = '1.3.0'
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = 'v0.ovapi.nl'
 
 CONF_STOP_CODE = 'stop_code'
+CONF_TIMING_POINT_CODE = 'timing_point_code'
 CONF_ROUTE_CODE = 'route_code'
 CONF_SHOW_FUTURE_DEPARTURES = 'show_future_departures'
 CONF_DATE_FORMAT = 'date_format'
@@ -34,6 +35,7 @@ DEFAULT_SHOW_FUTURE_DEPARTURES = 0
 ATTR_NAME = 'name'
 ATTR_STOP_CODE = 'stop_code'
 ATTR_ROUTE_CODE = 'route_code'
+ATTR_TIMING_POINT_CODE = 'timing_point_code'
 ATTR_ICON = 'icon'
 ATTR_DESTINATION = 'destination'
 ATTR_PROVIDER = 'provider'
@@ -51,6 +53,7 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_STOP_CODE, default=CONF_STOP_CODE): cv.string,
+    vol.Optional(CONF_TIMING_POINT_CODE, default=CONF_TIMING_POINT_CODE): cv.string,
     vol.Optional(CONF_ROUTE_CODE, default=CONF_ROUTE_CODE): cv.string,
     vol.Optional(CONF_SHOW_FUTURE_DEPARTURES, default=DEFAULT_SHOW_FUTURE_DEPARTURES): cv.positive_int,
     vol.Optional(CONF_DATE_FORMAT, default=DEFAULT_DATE_FORMAT): cv.string,
@@ -61,12 +64,13 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     name = config.get(CONF_NAME)
     stop_code = config.get(CONF_STOP_CODE)
+    timing_point_code = config.get(CONF_TIMING_POINT_CODE)
     route_code = config.get(CONF_ROUTE_CODE)
     future_departures = config.get(CONF_SHOW_FUTURE_DEPARTURES)
 
     async_get_clientsession(hass)
 
-    ov_api = OvApiData(stop_code)
+    ov_api = OvApiData(stop_code, timing_point_code)
 
     await ov_api.async_update()
 
@@ -77,18 +81,20 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     for counter in range(future_departures + 1):
         if counter == 0:
-            sensors.append(OvApiSensor(ov_api, (name + "_future_" + str(counter + 1)), stop_code, route_code, counter))
+            sensors.append(OvApiSensor(ov_api, name, stop_code, timing_point_code, route_code, counter))
         else:
-            sensors.append(OvApiSensor(ov_api, (name + "_future_" + str(counter + 1)), stop_code, route_code, counter))
+            sensors.append(OvApiSensor(ov_api, (name + "_future_" + str(counter)), stop_code, timing_point_code,
+                                       route_code, counter))
 
     async_add_entities(sensors, True)
 
 
 class OvApiSensor(Entity):
-    def __init__(self, ovapi, name, stop_code, route_code, counter):
+    def __init__(self, ovapi, name, stop_code, timing_point_code, route_code, counter):
         self._json_data = ovapi
         self._name = name
         self._stop_code = stop_code
+        self._timing_point_code = timing_point_code
         self._route_code = route_code
         self._sensor_number = counter
         self._icon = None
@@ -152,25 +158,27 @@ class OvApiSensor(Entity):
         """Return the state attributes."""
         if self._sensor_number == 0:
             return{
-            ATTR_NAME: self._name,
-            ATTR_STOP_CODE: self._stop_code,
-            ATTR_ROUTE_CODE: self._route_code,
-            ATTR_ICON: self._icon,
-            ATTR_DESTINATION: self._destination,
-            ATTR_PROVIDER: self._provider,
-            ATTR_TRANSPORT_TYPE: self._transport_type,
-            ATTR_LINE_NAME: self._line_name,
-            ATTR_STOP_NAME: self._stop_name,
-            ATTR_DEPARTURE: self._departure,
-            ATTR_DELAY: self._delay,
-            ATTR_DEPARTURES: self._departures,
-            ATTR_UPDATE_CYCLE: str(MIN_TIME_BETWEEN_UPDATES.seconds) + ' seconds',
-            ATTR_CREDITS: CONF_CREDITS
-        }
+                ATTR_NAME: self._name,
+                ATTR_STOP_CODE: self._stop_code,
+                ATTR_TIMING_POINT_CODE: self._timing_point_code,
+                ATTR_ROUTE_CODE: self._route_code,
+                ATTR_ICON: self._icon,
+                ATTR_DESTINATION: self._destination,
+                ATTR_PROVIDER: self._provider,
+                ATTR_TRANSPORT_TYPE: self._transport_type,
+                ATTR_LINE_NAME: self._line_name,
+                ATTR_STOP_NAME: self._stop_name,
+                ATTR_DEPARTURE: self._departure,
+                ATTR_DELAY: self._delay,
+                ATTR_DEPARTURES: self._departures,
+                ATTR_UPDATE_CYCLE: str(MIN_TIME_BETWEEN_UPDATES.seconds) + ' seconds',
+                ATTR_CREDITS: CONF_CREDITS
+            }
         else:
             return {
                 ATTR_NAME: self._name,
                 ATTR_STOP_CODE: self._stop_code,
+                ATTR_TIMING_POINT_CODE: self._timing_point_code,
                 ATTR_ROUTE_CODE: self._route_code,
                 ATTR_ICON: self._icon,
                 ATTR_DESTINATION: self._destination,
@@ -189,23 +197,35 @@ class OvApiSensor(Entity):
 
         data = json.loads(self._json_data.result)
 
-        for item in data[self._stop_code][self._route_code]['Passes'].values():
-            self._destination = item['DestinationName50']
-            self._provider = item['DataOwnerCode']
-            self._transport_type = item['TransportType'].title()
-            self._line_name = self._transport_type + ' ' + item['LinePublicNumber'] + ' - ' + self._destination
-            self._stop_name = item['TimingPointName']
+        stops = {}
+
+        if self._stop_code != CONF_STOP_CODE and self._stop_code is not None:
+            self._timing_point_code = None
+            stops = itertools.islice(data[self._stop_code][self._route_code]['Passes'].values(), 5)
+        elif self._timing_point_code != CONF_TIMING_POINT_CODE and self._timing_point_code is not None:
+            self._stop_code = None
+            stops = itertools.islice(data[self._timing_point_code]['Passes'].values(), 5)
+        else:
+            _LOGGER.error("Impossible to get data from OvApi, no stop code and no timing point code!")
 
         stops_list = []
-        for stop in itertools.islice(data[self._stop_code][self._route_code]['Passes'].values(), 5):
-            stops_item = {}
+        for stop in stops:
             target_departure_time = datetime.strptime(stop['TargetDepartureTime'], "%Y-%m-%dT%H:%M:%S")
             expected_arrival_time = datetime.strptime(stop['ExpectedDepartureTime'], "%Y-%m-%dT%H:%M:%S")
             calculate_delay = expected_arrival_time - target_departure_time
             delay = round(calculate_delay.seconds / 60)
-            stops_item["TargetDepartureTime"] = target_departure_time.time()
-            stops_item["ExpectedArrivalTime"] = expected_arrival_time.time()
-            stops_item["Delay"] = delay
+
+            stops_item = {
+                "destination": stop['DestinationName50'],
+                "provider": stop['DataOwnerCode'],
+                "transport_type": stop['TransportType'].title(),
+                "line_name": stop['TransportType'].title() + ' ' + stop['LinePublicNumber'] + ' - ' +
+                             stop['DestinationName50'],
+                "stop_name": stop['TimingPointName'],
+                "TargetDepartureTime": target_departure_time.time(),
+                "ExpectedArrivalTime": expected_arrival_time.time(),
+                "Delay": delay
+            }
             stops_list.append(stops_item)
 
         if data is None:
@@ -221,6 +241,13 @@ class OvApiSensor(Entity):
                 self._state = STATE_UNKNOWN
             else:
                 stops_list.sort(key=operator.itemgetter('TargetDepartureTime'))
+
+                self._destination = stops_list[self._sensor_number]["destination"]
+                self._provider = stops_list[self._sensor_number]["provider"]
+                self._transport_type = stops_list[self._sensor_number]["transport_type"]
+                self._line_name = stops_list[self._sensor_number]["line_name"]
+                self._stop_name = stops_list[self._sensor_number]["stop_name"]
+
                 self._departure = stops_list[self._sensor_number]["TargetDepartureTime"].strftime('%H:%M')
                 self._delay = str(stops_list[self._sensor_number]["Delay"])
 
@@ -244,7 +271,7 @@ class OvApiSensor(Entity):
                     if stops_list[self._sensor_number]["Delay"] == 0:
                         self._state = self._departure
                     else:
-                        self._state = self._departure + ' - Vertraging: %s min', self._delay
+                        self._state = self._departure + ' - Vertraging: ' + str(self._delay) + ' min'
 
         if self._transport_type == "Tram":
             self._icon = 'mdi:train'
@@ -255,9 +282,10 @@ class OvApiSensor(Entity):
 
 
 class OvApiData:
-    def __init__(self, stop_code):
+    def __init__(self, stop_code, timing_point_code):
         self._resource = _RESOURCE
         self._stop_code = stop_code
+        self._timing_point_code = timing_point_code
         self.result = ""
         self._headers = {
             'cache-control': "no-cache",
@@ -266,11 +294,24 @@ class OvApiData:
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self):
-        try:
-            response = http.client.HTTPConnection(self._resource)
-            response.request("GET", "/stopareacode/" + self._stop_code, headers = self._headers)
-            result = response.getresponse()
-            self.result = result.read().decode('utf-8')
-        except http.client.HTTPException:
-            _LOGGER.error("Impossible to get data from OvApi")
-            self.result = "Impossible to get data from OvApi"
+        if self._stop_code == CONF_STOP_CODE and self._timing_point_code == CONF_TIMING_POINT_CODE:
+            _LOGGER.error("Impossible to get data from OvApi, no stop code and no timing point code.")
+            self.result = "Impossible to get data from OvApi, no stop code and no timing point code."
+        elif self._stop_code != CONF_STOP_CODE:
+            try:
+                response = http.client.HTTPConnection(self._resource)
+                response.request("GET", "/stopareacode/" + self._stop_code, headers = self._headers)
+                result = response.getresponse()
+                self.result = result.read().decode('utf-8')
+            except http.client.HTTPException:
+                _LOGGER.error("Impossible to get data from OvApi using stop code.")
+                self.result = "Impossible to get data from OvApi using stop code."
+        else:
+            try:
+                response = http.client.HTTPConnection(self._resource)
+                response.request("GET", "/tpc/" + self._timing_point_code, headers = self._headers)
+                result = response.getresponse()
+                self.result = result.read().decode('utf-8')
+            except http.client.HTTPException:
+                _LOGGER.error("Impossible to get data from OvApi using timing point code.")
+                self.result = "Impossible to get data from OvApi using timing point code."


### PR DESCRIPTION
- Support for timing_point_code if no stop_code available (No route_code needed, view rolfberkenbosch post for optaining timing_point_code for docs) Example config:
```yaml
- platform: ovapi
  name: Edzemaheerd
  timing_point_code: '10155690'
  show_future_departures: 4
```
- FIXED wrong sensor name introduced by latest pull
- FIXED attributes like provider, line_name, destination for future sensors