### PR TITLE
Update sensor.py to sort correctly

### DIFF
--- a/custom_components/ovapi/sensor.py
+++ b/custom_components/ovapi/sensor.py
@@ -233,6 +233,7 @@ class OvApiSensor(Entity):
                                  stop['DestinationName50'],
                     "stop_name": stop['TimingPointName'],
                     "TargetDepartureTime": target_departure_time.time(),
+                    "TargetDepartureDateTime": target_departure_time,
                     "ExpectedArrivalTime": expected_arrival_time.time(),
                     "Delay": delay
                 }
@@ -251,7 +252,7 @@ class OvApiSensor(Entity):
                 self._departures = STATE_UNKNOWN
                 self._state = STATE_UNKNOWN
             else:
-                stops_list.sort(key=operator.itemgetter('TargetDepartureTime'))
+                stops_list.sort(key=operator.itemgetter('TargetDepartureDateTime'))
 
                 self._destination = stops_list[self._sensor_number]["destination"]
                 self._provider = stops_list[self._sensor_number]["provider"]


### PR DESCRIPTION
The issue with current sorting starts when we have in list times from two separate days:
Some transport that should come at 23:00(current day), and some at 00:01(next day).

Because of the current implementation, 00:01 of the current day will be first, and 23:00 will be second.
It's not correct. That's why I propose to modify sorting.