### PR TITLE
Added version to manifest.json

### DIFF
--- a/custom_components/ovapi/manifest.json
+++ b/custom_components/ovapi/manifest.json
@@ -4,5 +4,6 @@
     "documentation": "https://github.com/Paul-dH/Home-Assisant-Sensor-OvApi",
     "dependencies": [],
     "codeowners": [],
-    "requirements": []
+    "requirements": [],
+    "version": "1.4.3"
   }


### PR DESCRIPTION
Fixing:

2021-04-12 20:58:32 WARNING (MainThread) [homeassistant.loader] No 'version' key in the manifest file for custom integration 'ovapi'. As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'ovapi'

Related to: #27