### PR TITLE
Many-updates-in-one pull request...

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ This is a sensor for Home Assistant and it will retrieve departure information o
 
 ### Install:
 - Create the following folder structure: /config/custom_components/ovapi and place these [3 files](https://github.com/Paul-dH/Home-Assisant-Sensor-OvApi/tree/master/custom_components/ovapi) there.
+- restart Home Assistant to make the platform 'ovapi' available for configuration
 - Add the configuration to configuration.yaml, see the parameter descriptions below and refer to the examples.
+- restart Home Assistant to create the entities as per your configuration
+- entities are now active and ready to use and display
 
 ### Sensor options (there are two ways to use the sensor):
 
@@ -28,7 +31,7 @@ This is a sensor for Home Assistant and it will retrieve departure information o
 - **line_filter** *(int, comma seperated)* - You might bump into the fact that there are multiple lines that use the same stop, with this property you can filter all passes with the line number that you want.
 
 
-### To find the stop_code (stopareacode) refer to the JSON response of: [v0.ovapi.nl](http://v0.ovapi.nl/stopareacode)
+### To find the stop_code (stopareacode) refer to the JSON response of: [v0.ovapi.nl/stopareacode](http://v0.ovapi.nl/stopareacode)
 I've used the building JSON parser from Firefox, the search input is on the top right.
 
 - Search in the response with a keyword of the stop or the line you want, eg: kastelenring
@@ -44,15 +47,17 @@ I've used the building JSON parser from Firefox, the search input is on the top 
 - Open one of the stops
 - Look for the key 'DestinationName50', this should hold the destination that you want. If this is the wrong way, then you should close the JSON output and open the other route code key.
 - Note the route_code and the stop_code and place these values in the sensor configuration.
+- Optionally use the line filter argument to filter only the line(s) that you want to see.
 
 
-### To find the timing_point_code (TimingPointCode) refer to the JSON response of: [v0.ovapi.nl](http://v0.ovapi.nl/line)
+### To find the timing_point_code (TimingPointCode) refer to the JSON response of: [v0.ovapi.nl/line](http://v0.ovapi.nl/line)
 I've used the building JSON parser from Firefox, the search input is on the top right.
 
 - Search in the response with a keyword of the destination of the line, eg: Leyenburg
 - The result of this should be a list of line identifiers, expand them and look for the one that has the correct value in `DestinationName50`. Copy the line identifier, e.g. HTM_6_2.
 - Next, open the url: [http://v0.ovapi.nl/line/HTM_6_2](http://v0.ovapi.nl/line/HTM_6_2), this page lists all stops of the line. Search for your stop name, e.g. kastelenring.
 - Find the TimingPointCode and use this as value in the sensor configuration.
+- Optionally use the line filter argument to filter only the line(s) that you want to see.
 
 ### Sensor configuration examples
 Create 1 sensor to show the next upcomming departure of a particular line

--- a/custom_components/ovapi/__init__.py
+++ b/custom_components/ovapi/__init__.py
@@ -13,6 +13,11 @@ from .const import DOMAIN, PLATFORMS, STARTUP_MESSAGE
 
 _LOGGER = logging.getLogger(__name__)
 
+DOMAIN: Final = "ovapi"
+    
+PLATFORMS = [
+    Platform.SENSOR,
+]
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the platforms."""

--- a/custom_components/ovapi/__init__.py
+++ b/custom_components/ovapi/__init__.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+from homeassistant.const import SERVICE_RELOAD
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.reload import async_reload_integration_platforms
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN, PLATFORMS, STARTUP_MESSAGE
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the platforms."""
+    # Print startup message
+    _LOGGER.info("ovapi component is starting...")
+
+    # await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
+
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    async def reload_service_handler(service: ServiceCall) -> None:
+        """Reload all sensors from config."""
+        print("+++++++++++++++++++++++++")
+        print(component)
+        # print(hass.data[DATA_INSTANCES]["sensors"].entities[0])
+
+        await async_reload_integration_platforms(hass, DOMAIN, PLATFORMS)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_RELOAD, reload_service_handler, schema=vol.Schema({})
+    )
+
+    return True

--- a/custom_components/ovapi/__init__.py
+++ b/custom_components/ovapi/__init__.py
@@ -1,17 +1,16 @@
-from __future__ import annotations
-
 import logging
 
 import voluptuous as vol
-from homeassistant.const import SERVICE_RELOAD
+from homeassistant.const import SERVICE_RELOAD, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.reload import async_reload_integration_platforms
 from homeassistant.helpers.typing import ConfigType
+from typing import Final
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "ovapi"
+DOMAIN: Final = "ovapi"
     
 PLATFORMS = [
     Platform.SENSOR,

--- a/custom_components/ovapi/__init__.py
+++ b/custom_components/ovapi/__init__.py
@@ -9,11 +9,9 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.reload import async_reload_integration_platforms
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, PLATFORMS, STARTUP_MESSAGE
-
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN: Final = "ovapi"
+DOMAIN = "ovapi"
     
 PLATFORMS = [
     Platform.SENSOR,

--- a/custom_components/ovapi/sensor.py
+++ b/custom_components/ovapi/sensor.py
@@ -34,9 +34,6 @@ DEFAULT_DATE_FORMAT = "%y-%m-%dT%H:%M:%S"
 DEFAULT_SHOW_FUTURE_DEPARTURES = 0
 
 ATTR_NAME = 'name'
-ATTR_STOP_CODE = 'stop_code'
-ATTR_ROUTE_CODE = 'route_code'
-ATTR_TIMING_POINT_CODE = 'timing_point_code'
 ATTR_OVAPI_SEARCH_CODE = 'search_code'
 ATTR_LINE_FILTER = 'line_filter'
 ATTR_ICON = 'icon'
@@ -184,9 +181,6 @@ class OvApiSensor(Entity):
         if self._sensor_number == 0:
             return{
                 ATTR_NAME: self._name,
-                ATTR_STOP_CODE: self._stop_code,
-                ATTR_ROUTE_CODE: self._route_code,
-                ATTR_TIMING_POINT_CODE: self._timing_point_code,
                 ATTR_OVAPI_SEARCH_CODE: code_display,
                 ATTR_LINE_FILTER: filter,
                 ATTR_ICON: self._icon,
@@ -204,9 +198,6 @@ class OvApiSensor(Entity):
         else:
             return {
                 ATTR_NAME: self._name,
-                ATTR_STOP_CODE: self._stop_code,
-                ATTR_ROUTE_CODE: self._route_code,
-                ATTR_TIMING_POINT_CODE: self._timing_point_code,
                 ATTR_OVAPI_SEARCH_CODE: code_display,
                 ATTR_LINE_FILTER: filter,
                 ATTR_ICON: self._icon,
@@ -296,22 +287,10 @@ class OvApiSensor(Entity):
 
                     for counter, stop in enumerate(next_stops_list):
                         if counter <= 11:
-                            if next_stops_list[counter]["Delay"] == 0:
-                                departure_list.append(next_stops_list[counter]["TargetDepartureTime"].strftime('%H:%M'))
-                            else:
-                                departure_list.append(next_stops_list[counter]["TargetDepartureTime"].strftime('%H:%M') +
-                                                      " + " + str(next_stops_list[counter]["Delay"]) + "m")
+                            departure_list.append(next_stops_list[counter]["TargetDepartureTime"].strftime('%H:%M') + next_stops_list[counter]["Delay"])
                     self._departures = departure_list
 
-                    if stops_list[self._sensor_number]["Delay"] == 0:
-                        self._state = self._departure
-                    else:
-                        self._state = stops_list[self._sensor_number]["ExpectedArrivalTime"].strftime('%H:%M')
-                else:
-                    if stops_list[self._sensor_number]["Delay"] == 0:
-                        self._state = self._departure
-                    else:
-                        self._state = self._departure + ' +' + str(self._delay) + 'm'
+                self._state = self._departure + self._delay
 
         if self._transport_type == "Tram":
             self._icon = 'mdi:train'

--- a/custom_components/ovapi/sensor.py
+++ b/custom_components/ovapi/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.util import Throttle
 
 import homeassistant.helpers.config_validation as cv
 
-__version__ = '1.4.2a'
+__version__ = '1.4.3'
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = 'v0.ovapi.nl'
@@ -247,7 +247,7 @@ class OvApiSensor(Entity):
                 else
                     delay = ''
                     
-                if expected_arrival_time < datetime.now():
+                if expected_arrival_time < (datetime.now() + timedelta(minutes=1)):
                     minutes_to_go = 'Now'
                 else:
                     minutes_to_go = 'in ' + str(round((expected_arrival_time - datetime.now()).seconds / 60)) + ' min.'

--- a/custom_components/ovapi/sensor.py
+++ b/custom_components/ovapi/sensor.py
@@ -219,7 +219,7 @@ class OvApiSensor(Entity):
 
         stops_list = []
         for stop in stops:
-            if self._line_filter == ATTR_LINE_FILTER or stop['LinePublicNumber'] in self._line_filter.split(", "):
+            if (self._line_filter == ATTR_LINE_FILTER or stop['LinePublicNumber'] in self._line_filter.split(", ")) and (stop['JourneyStopType'] != "LAST"):
                 target_departure_time = datetime.strptime(stop['TargetDepartureTime'], "%Y-%m-%dT%H:%M:%S")
                 expected_arrival_time = datetime.strptime(stop['ExpectedDepartureTime'], "%Y-%m-%dT%H:%M:%S")
                 calculate_delay = expected_arrival_time - target_departure_time

--- a/custom_components/ovapi/sensor.py
+++ b/custom_components/ovapi/sensor.py
@@ -262,13 +262,13 @@ class OvApiSensor(Entity):
             self._departure = STATE_UNKNOWN
             self._delay = STATE_UNKNOWN
             self._departures = STATE_UNKNOWN
-            self._state = STATE_UNKNOWN
+            self._state = '--:--'
         else:
             if self._sensor_number >= len(stops_list):
                 self._departure = STATE_UNKNOWN
                 self._delay = STATE_UNKNOWN
                 self._departures = STATE_UNKNOWN
-                self._state = STATE_UNKNOWN
+                self._state = '--:--'
             else:
                 stops_list.sort(key=operator.itemgetter('TargetDepartureDateTime'))
 

--- a/custom_components/ovapi/sensor.py
+++ b/custom_components/ovapi/sensor.py
@@ -44,6 +44,7 @@ ATTR_LINE_NAME = 'line_name'
 ATTR_STOP_NAME = 'stop_name'
 ATTR_DEPARTURE = 'departure'
 ATTR_DELAY = 'delay'
+ATTR_MINUTES_TO_GO = 'arrives'
 ATTR_DEPARTURES = 'departures'
 ATTR_UPDATE_CYCLE = 'update_cycle'
 ATTR_CREDITS = 'credits'
@@ -107,6 +108,7 @@ class OvApiSensor(Entity):
         self._stop_name = None
         self._departure = None
         self._delay = None
+        self._minutes_to_go = None
         self._departures = None
         self._state = None
 
@@ -191,6 +193,7 @@ class OvApiSensor(Entity):
                 ATTR_STOP_NAME: self._stop_name,
                 ATTR_DEPARTURE: self._departure,
                 ATTR_DELAY: delay_display,
+                ATTR_MINUTES_TO_GO: self._minutes_to_go,
                 ATTR_DEPARTURES: self._departures,
                 ATTR_UPDATE_CYCLE: str(MIN_TIME_BETWEEN_UPDATES.seconds) + ' seconds',
                 ATTR_CREDITS: CONF_CREDITS
@@ -208,6 +211,7 @@ class OvApiSensor(Entity):
                 ATTR_STOP_NAME: self._stop_name,
                 ATTR_DEPARTURE: self._departure,
                 ATTR_DELAY: delay_display,
+                ATTR_MINUTES_TO_GO: self._minutes_to_go,
                 ATTR_UPDATE_CYCLE: str(MIN_TIME_BETWEEN_UPDATES.seconds) + ' seconds',
                 ATTR_CREDITS: CONF_CREDITS
             }
@@ -242,6 +246,11 @@ class OvApiSensor(Entity):
                     delay = ' -' + str(round(calculate_delay.seconds / 60)) + 'm'
                 else
                     delay = ''
+                    
+                if expected_arrival_time < datetime.now():
+                    minutes_to_go = 'Now'
+                else:
+                    minutes_to_go = 'in ' + str(round((expected_arrival_time - datetime.now()).seconds / 60)) + ' min.'
 
                 stops_item = {
                     "destination": stop['DestinationName50'],
@@ -253,7 +262,8 @@ class OvApiSensor(Entity):
                     "TargetDepartureTime": target_departure_time.time(),
                     "TargetDepartureDateTime": target_departure_time,
                     "ExpectedArrivalTime": expected_arrival_time.time(),
-                    "Delay": delay
+                    "Delay": delay,
+                    "Minutes_to_go": minutes_to_go
                 }
 
                 stops_list.append(stops_item)
@@ -280,6 +290,7 @@ class OvApiSensor(Entity):
 
                 self._departure = stops_list[self._sensor_number]["TargetDepartureTime"].strftime('%H:%M')
                 self._delay = str(stops_list[self._sensor_number]["Delay"])
+                self._minutes_to_go = stop_list[self._sensor_number]["Minutes_to_go"]
 
                 if self._sensor_number == 0:
                     departure_list = []

--- a/custom_components/ovapi/sensor.py
+++ b/custom_components/ovapi/sensor.py
@@ -219,7 +219,7 @@ class OvApiSensor(Entity):
 
         stops_list = []
         for stop in stops:
-            if (self._line_filter == ATTR_LINE_FILTER or stop['LinePublicNumber'] in self._line_filter.split(", ")) and (stop['JourneyStopType'] != "LAST"):
+            if (self._line_filter == ATTR_LINE_FILTER or stop['LinePublicNumber'] in self._line_filter.split(", ")) and (stop['JourneyStopType'] != 'LAST'):
                 target_departure_time = datetime.strptime(stop['TargetDepartureTime'], "%Y-%m-%dT%H:%M:%S")
                 expected_arrival_time = datetime.strptime(stop['ExpectedDepartureTime'], "%Y-%m-%dT%H:%M:%S")
                 calculate_delay = expected_arrival_time - target_departure_time

--- a/custom_components/ovapi/sensor.py
+++ b/custom_components/ovapi/sensor.py
@@ -95,6 +95,7 @@ class OvApiSensor(Entity):
     def __init__(self, ov_api, name, stop_code, timing_point_code, route_code, line_filter, counter):
         self._json_data = ov_api
         self._name = name
+        self._unique_id = name.replace(' ','_')
         self._stop_code = stop_code
         self._timing_point_code = timing_point_code
         self._route_code = route_code
@@ -116,7 +117,12 @@ class OvApiSensor(Entity):
         """Return the name of the sensor."""
         return self._name
 
-    @property
+   @property
+    def unique_id(self):
+        """Return the name of the sensor."""
+        return self._unique_id
+
+   @property
     def icon(self):
         return self._icon
 

--- a/custom_components/ovapi/sensor.py
+++ b/custom_components/ovapi/sensor.py
@@ -293,7 +293,7 @@ class OvApiSensor(Entity):
                 self._state = self._departure + self._delay
 
         if self._transport_type == "Tram":
-            self._icon = 'mdi:train'
+            self._icon = 'mdi:tram'
         if self._transport_type == "Bus":
             self._icon = 'mdi:bus'
         if self._transport_type == "Metro":

--- a/custom_components/ovapi/services.yaml
+++ b/custom_components/ovapi/services.yaml
@@ -1,0 +1,3 @@
+reload:
+  name: Reload
+  description: Reload all ovapi sensor entities


### PR DESCRIPTION
Hi, when the stop queried is the first/last one of the line, there are chances that there are duplicated records, for the tram/bus that arrives and for when it leaves. I have seen this for example for this code:

https://v0.ovapi.nl/tpc/31008732

The same metro arrives and leaves the other way with the same route code and the same time, therefore I propose to ignore times of departure when the stop is the last stop of the line, i.e. the 'JourneyStopType' attribute is 'LAST'.

For me this cleanly deduplicates the timings at this stop. I tested the change locally and it works fine for me.